### PR TITLE
feat(admin): allow editing of tunes after pasting from spreadsheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4944,20 +4944,6 @@
 				}
 			}
 		},
-		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/svelte-check/node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",


### PR DESCRIPTION
This commit refactors the admin tune addition page to allow for form-based editing of tune data after it has been pasted from a spreadsheet.

Previously, pasting from a spreadsheet would only show a preview table, and you could only save all tunes at once.

This change introduces the following:
- When spreadsheet data is pasted, it now populates a list of editable forms, one for each tune.
- Each form is pre-filled with the parsed data.
- You can edit the values in each form before saving.
- Each tune form has its own "Save" button to save that specific tune individually.
- The "Save All" button is retained to save any remaining tunes in the list.